### PR TITLE
patch: make destintaion param opitonal, if no dest -> copy to cwd

### DIFF
--- a/src/__tests__/integration/CopySourceStrategies.spec.ts
+++ b/src/__tests__/integration/CopySourceStrategies.spec.ts
@@ -56,8 +56,23 @@ describe("GithubCopySourceStrategy", () => {
       console.log("files", files);
 
       expect(files[0]).toEqual("README.md");
+    });
 
-      expect(true).toBeTruthy();
+    it("should copy to cwd if no destination is provided", async () => {
+      const ghFileUrl =
+        "https://github.com/kujo205/musc/blob/dev/svelte.config.js";
+
+      await strategy.copy(ghFileUrl);
+
+      const files = fs.readdirSync(".");
+
+      const hasSvelteConfigFile = files.includes("svelte.config.js");
+
+      if (hasSvelteConfigFile) {
+        fs.unlinkSync("svelte.config.js");
+      }
+
+      expect(hasSvelteConfigFile).toEqual(true);
     });
   });
 });

--- a/src/modules/commands/MainCopyCommand/index.ts
+++ b/src/modules/commands/MainCopyCommand/index.ts
@@ -9,7 +9,8 @@ export class MainCopyCommand implements CommandWrapper {
   constructor() {
     this.command = new Command()
       .name("main")
-      .arguments("<source> <destination>")
+      .arguments("<source>")
+      .option("-d, --destination <destination>", "Destination folder", ".")
       .description("Copy from source to destination")
       .action(this.handleAction.bind(this));
   }


### PR DESCRIPTION
This pull request enhances the functionality of the `GithubCopySourceStrategy` and the `MainCopyCommand` class to improve file copying behavior. The most important changes include adding a test for copying files to the current working directory when no destination is provided and updating the command-line interface to make the destination optional with a default value.

### Enhancements to file copying behavior:

* [`src/__tests__/integration/CopySourceStrategies.spec.ts`](diffhunk://#diff-069edb9a481575f506bb53b13b92539922446f040ad94e4721ca0373ad4d3708R59-R75): Added a new test case to verify that files are copied to the current working directory (`cwd`) when no destination is specified. This ensures the functionality works as expected and adds robustness to the test suite.

### Improvements to command-line interface:

* [`src/modules/commands/MainCopyCommand/index.ts`](diffhunk://#diff-c446bbca3ff83745d18991c46d1751ab9d95095672f5a3081ade823278b96dcaL12-R13): Updated the `MainCopyCommand` class to make the `destination` argument optional by introducing a `--destination` option with a default value of `"."`. This simplifies the command usage while maintaining flexibility for specifying a custom destination.